### PR TITLE
Add username to url regex

### DIFF
--- a/index.js
+++ b/index.js
@@ -8,7 +8,7 @@ module.exports = function remote (cb) {
       if (stderr) return cb(stderr);
       
       var m = stdout.match(
-        /origin\s+(?:git@github\.com:|(?:https?|git):\/\/github\.com\/)(\S+)/
+        /origin\s+(?:git@github\.com:|(?:https?|git):\/\/(?:.+@)?github\.com\/)(\S+)/
       );
       if (!m) return cb('no github remote found');
       cb(null, m[1].replace(/\.git$/, ''));


### PR DESCRIPTION
Module was failing to find remote from output with a username, e.g: 

``` bash
$ git remote -v
origin  https://blefevre@github.com/blefevre/resolve-git-remote.git
```

Modified regex to handle a username.
